### PR TITLE
Correct contract keyword

### DIFF
--- a/docs/docs/learn-about-crowdsales.md
+++ b/docs/docs/learn-about-crowdsales.md
@@ -105,7 +105,7 @@ contract MyCrowdsale is Crowdsale, MintedCrowdsale {
     }
 }
 
-constract MyCrowdsaleDeployer {
+contract MyCrowdsaleDeployer {
     constructor()
         public
     {


### PR DESCRIPTION
Correct `constract MyCrowdsaleDeployer` to `contract MyCrowdsaleDeployer` in the Minted Crowdsale code example.