### PR TITLE
Fix broken link to counters.sol

### DIFF
--- a/docs/docs/learn-about-utilities.md
+++ b/docs/docs/learn-about-utilities.md
@@ -91,6 +91,6 @@ If you want to Escrow some funds, check out [`Escrow`](https://github.com/OpenZe
 
 Want to check if an address is a contract? Use [`Address`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/Address.sol) and `Address#isContract()`.
 
-Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.1.2/contracts/drafts/Counter.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
+Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.1.2/contracts/drafts/Counter.sol). This is especially useful for creating incremental ERC721 tokenIds like we did in the last section.
 
 

--- a/docs/docs/learn-about-utilities.md
+++ b/docs/docs/learn-about-utilities.md
@@ -92,6 +92,6 @@ If you want to Escrow some funds, check out [`Escrow`](https://github.com/OpenZe
 
 Want to check if an address is a contract? Use [`AddressUtils`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/Address.sol) and `AddressUtils#isContract()`.
 
-Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/ae02103e47af2df8471bfd11bc171d5b53cd022c/contracts/drafts/Counter.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
+Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.1.2/contracts/drafts/Counter.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
 
 

--- a/docs/docs/learn-about-utilities.md
+++ b/docs/docs/learn-about-utilities.md
@@ -92,6 +92,6 @@ If you want to Escrow some funds, check out [`Escrow`](https://github.com/OpenZe
 
 Want to check if an address is a contract? Use [`AddressUtils`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/Address.sol) and `AddressUtils#isContract()`.
 
-Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/drafts/Counters.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
+Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/ae02103e47af2df8471bfd11bc171d5b53cd022c/contracts/drafts/Counter.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
 
 

--- a/docs/docs/learn-about-utilities.md
+++ b/docs/docs/learn-about-utilities.md
@@ -92,6 +92,6 @@ If you want to Escrow some funds, check out [`Escrow`](https://github.com/OpenZe
 
 Want to check if an address is a contract? Use [`AddressUtils`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/Address.sol) and `AddressUtils#isContract()`.
 
-Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/Counter.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
+Want to keep track of some numbers that increment by 1 every time you want another one? Check out [`Counter`](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/drafts/Counters.sol). This is especailly useful for creating incremental ERC721 tokenIds like we did in the last section.
 
 


### PR DESCRIPTION
The "Check out Counter" link now points to: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/drafts/Counters.sol